### PR TITLE
Make PlaceholderAPI Placeholders Persistent

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/hook/PlaceholderHook.java
+++ b/core/src/main/java/be/isach/ultracosmetics/hook/PlaceholderHook.java
@@ -79,4 +79,9 @@ public class PlaceholderHook extends PlaceholderExpansion {
     public String getVersion() {
         return ultraCosmetics.getDescription().getVersion();
     }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Currently, if you reload PlaceholderAPI in any way (e.g., using the reload command), UltraCosmetics placeholders get unregistered and won't be registered again. In this PR, I've set `persist` to true in the placeholder hook to ensure it works as expected.

#### Changes

- [X] Override persist behavior to true in PlaceholderAPI hook
