### PR TITLE
Add reviewer for Gradle Wrapper updates

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           release-channel: stable
           labels: dependencies
+          reviewers: BySwiizen


### PR DESCRIPTION
### What is the purpose of this pull request?

1. Added a reviewer for Gradle Wrapper updates. This avoids having to add it manually.

#### Changes

- [x] Use GitHub checklists to list things you've done or are still working on.
