### PR TITLE
Fix versioning Spigot for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["org.spigotmc:spigot-api"],
-      "versioning": "regex:^(?<major>\\\\d+)\\\\.(?<minor>\\\\d+)(\\\\.(?<patch>\\\\d+))?-(?<compatibility>.*)$"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(\\.(?<patch>\\d+))?-(?<compatibility>.*)$"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,5 +11,11 @@
     "BySwiizen"
   ],
   "automerge": true,
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.spigotmc:spigot-api"],
+      "versioning": "regex:^(?<major>\\\\d+)\\\\.(?<minor>\\\\d+)(\\\\.(?<patch>\\\\d+))?-(?<compatibility>.*)$"
+    }
+  ]
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

1. Fixed Spigot versioning for Renovate not reaching PR when a new update was available.

#### Changes

- [x] Use GitHub checklists to list things you've done or are still working on.
