### PR TITLE
Support Custom Head Textures for Cosmetics

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
@@ -207,8 +207,8 @@ public abstract class CosmeticType<T extends Cosmetic<?>> {
     }
 
     public ItemStack getItemStack() {
-        String skull = SettingsManager.getConfig().getString(category.getConfigPath() + "." + getConfigName() + ".Custom-Skull", "");
-        if(!skull.isBlank() && !skull.isEmpty()) {
+        String skull = SettingsManager.getConfig().getString(category.getConfigPath() + "." + getConfigName() + ".Custom-Head");
+        if(skull != null) {
             return ItemFactory.createSkull(skull, "");
         }
         return material.parseItem();

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
@@ -9,6 +9,7 @@ import be.isach.ultracosmetics.cosmetics.Category;
 import be.isach.ultracosmetics.cosmetics.Cosmetic;
 import be.isach.ultracosmetics.cosmetics.PlayerAffectingCosmetic;
 import be.isach.ultracosmetics.player.UltraPlayer;
+import be.isach.ultracosmetics.util.ItemFactory;
 import be.isach.ultracosmetics.util.SmartLogger.LogLevel;
 import be.isach.ultracosmetics.version.ServerVersion;
 import com.cryptomorin.xseries.XMaterial;
@@ -206,6 +207,9 @@ public abstract class CosmeticType<T extends Cosmetic<?>> {
     }
 
     public ItemStack getItemStack() {
+        if(getMaterial().equals(XMaterial.PLAYER_HEAD)) {
+            return ItemFactory.createSkull(SettingsManager.getConfig().getString(category.getConfigPath() + "." + getConfigName() + ".Custom-Skull", ""), "");
+        }
         return material.parseItem();
     }
 

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/type/CosmeticType.java
@@ -207,8 +207,9 @@ public abstract class CosmeticType<T extends Cosmetic<?>> {
     }
 
     public ItemStack getItemStack() {
-        if(getMaterial().equals(XMaterial.PLAYER_HEAD)) {
-            return ItemFactory.createSkull(SettingsManager.getConfig().getString(category.getConfigPath() + "." + getConfigName() + ".Custom-Skull", ""), "");
+        String skull = SettingsManager.getConfig().getString(category.getConfigPath() + "." + getConfigName() + ".Custom-Skull", "");
+        if(!skull.isBlank() && !skull.isEmpty()) {
+            return ItemFactory.createSkull(skull, "");
         }
         return material.parseItem();
     }


### PR DESCRIPTION
### What is the purpose of this pull request?
1. Implements support for custom skull textures in cosmetic menus.
  - If a Custom-Head value is defined in the config, (at the path `category.configName.Custom-Head`) the cosmetic will use the specified texture.
  - If no custom head is specified, the fallback item material is used.

#### Changes

- [x] Updated getItemStack() to check for a Custom-Head config value before returning the default item material.
- [x] Refactored config handling to simplify checking and retrieval of custom head textures.
- [x] Removed unnecessary material checks, allowing direct overrides via config without requiring internal material registration.

Sample config:
```yaml
  ChristmasElf:
    Enabled: true
    # Whether to show description when hovering in GUI
    Show-Description: true
    # The higher the weight, the better the chance of
    # finding this cosmetic when this category is picked.
    # Fractional values are not allowed.
    # Set to 0 to disable finding in chests.
    Treasure-Chest-Weight: 1
    # Price to buy individually in GUI
    # Only works if No-Permission.Allow-Purchase is true and this setting > 0
    Purchase-Price: 0
    Custom-Head: 82ab6c79c63b8334b2c03b6f736acf61aced5c24f2ba72b777d77f28e8c
```


_Sorry that some of the commits revert older changes, I originally coded it with the intention that the material has to be specified as a player head but realized normal users (w/o modifying source) can't specify the material type. Just ended up reverting that change to check if the Custom-Head parameter was defined and overriding the material itemstack._