### PR TITLE
Fix gadget custom head texture not displaying on equip

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/gadgets/Gadget.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/gadgets/Gadget.java
@@ -184,7 +184,7 @@ public abstract class Gadget extends Cosmetic<GadgetType> implements UnmovableIt
     }
 
     public void updateItemStack() {
-        itemStack = ItemFactory.create(getType().getMaterial(), getItemDisplayName(), MessageManager.getLegacyMessage("Gadgets.Lore"));
+        itemStack = ItemFactory.rename(getType().getItemStack(), getItemDisplayName(), MessageManager.getLegacyMessage("Gadgets.Lore"));
         ItemFactory.applyCosmeticMarker(itemStack);
     }
 


### PR DESCRIPTION
# Fix Gadget custom head texture not displaying on equip

## What is the purpose of this pull request?

### 1. What does it do, and what issues does it solve?
This pull request fixes an issue where a gadget's custom head texture (specified via `Custom-Head` in the configuration) displays correctly in the cosmetic GUI but reverts to the default player head icon when equipped in the player's inventory. The change ensures that the custom texture is preserved during the equip process by leveraging the existing `getItemStack()` method from `CosmeticType`.

The issue occurred because the `updateItemStack()` method in the `Gadget` class previously created a new `ItemStack` using `getType().getMaterial()`, which ignored the `Custom-Head` texture. Now, it uses `getType().getItemStack()` to retain the custom texture, applying only the necessary name and lore updates.

Additionally, using custom head textures for gadgets prevents various exploits on survival servers. Players could previously obtain gadget items (e.g., a beacon from `DiscoBall`) through unintended means, such as dropping or glitching them out of the cosmetic system. This could disrupt server balance by granting access to powerful items. By consistently applying custom head textures, gadgets are visually and functionally distinct, reducing the risk of such exploits and maintaining gameplay integrity.

## Changes
- [x] Update `Gadget.updateItemStack()` to use `getType().getItemStack()` for preserving custom head textures.
- [x] Apply name and lore updates with `ItemFactory.rename`.
- [x] Retain cosmetic marker with `ItemFactory.applyCosmeticMarker`.

## How to Test
1. Ensure a gadget with a custom head texture is configured, e.g.:
   ```yaml
   Gadgets:
     BatBlaster:
       Custom-Head: '7f578c9c0fd1a63379d0d166d0fa94c0dd9dba970e5adf1d78dd8985272ab168'
   ```
2. Open the cosmetics menu and verify that `BatBlaster` displays the custom texture (e.g., a bat head).
3. Equip the gadget and check that the item in the player's inventory retains the same custom texture instead of reverting to a default player head.
4. (Optional) Test with a gadget like `DiscoBall` (originally a beacon) to ensure it displays as a custom head in the inventory, not a usable beacon item.