### PR TITLE
Exclude "Adventure" from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,6 @@ updates:
       - dependency-name: "net.wesjd:anvilgui"
       - dependency-name: "com.palmergames.bukkit.towny:towny"
       - dependency-name: "com.sk89q.worldguard:worldguard-bukkit"
+      - dependency-name: "net.kyori:adventure-text-minimessage"
+      - dependency-name: "net.kyori:adventure-text-serializer-plain"
+      - dependency-name: "net.kyori:adventure-api"


### PR DESCRIPTION
### What is the purpose of this pull request?

1. Exclude "Adventure" from Dependabot.

#### Changes

- [x] Use GitHub checklists to list things you've done or are still working on.
